### PR TITLE
Make channel name restrictions work correctly

### DIFF
--- a/src/statuspage.coffee
+++ b/src/statuspage.coffee
@@ -22,11 +22,13 @@
 #   roidrage, raventools
 
 module.exports = (robot) ->
+  getRoomNameFromMessage = (msg) ->
+    return robot.adapter.client.rtm.dataStore.getChannelById(msg.envelope.room).name
 
-  checkRoom = (msg, restricted_rooms) ->
-    return true if restricted_rooms == false
-    return false unless msg.envelope.room in restricted_rooms
-    return true
+  checkRoom = (msg, restrictedRooms) ->
+    return true if restrictedRooms == false
+    roomName = getRoomNameFromMessage(msg)
+    return roomName in restrictedRooms
 
   baseUrl = "https://api.statuspage.io/v1/pages/#{process.env.HUBOT_STATUS_PAGE_ID}"
   authHeader = Authorization: "OAuth #{process.env.HUBOT_STATUS_PAGE_TOKEN}"


### PR DESCRIPTION
![](https://media1.giphy.com/media/xT5LMEcHRXKXpIHCCI/giphy.gif)

The problem is that `msg.envelope.room` is not the name of a channel, but a channel ID. We were checking whether the channel ID was in a list of channel names, which is obviously never going to work.

I copied over the `getRoomNameFromMessage` method from our PagerDuty script, which is proven to work.